### PR TITLE
Correct README: construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@ mailgun-mustache-mailer
 
 This is a simple wrapper around mustache and mailgun.com's email API.
 
-It is constructed by supplying the domain and API-key obtained from mailgun.com.
+It is constructed by supplying the domain and API-key obtained from mailgun.com, as well as the email address that emails should appear to be sent from.
+A second argument, `log` is supplied, with a single method `info`, which is called when the mailer wants to log something.
 
 ``` javascript
 var MailgunMustacheMailer = require("mailgun-mustache-mailer");
-var config = { domain: "example.com", apiKey: "secret-mailgun-key"};
+var config = { domain: "example.com", apiKey: "secret-mailgun-key", from: "test@example.com" };
+var log = { info: console.log };
 
-var mailgunMustacheMailer = new MailgunMustacheMailer(config);
+var mailgunMustacheMailer = new MailgunMustacheMailer(config, log);
 ```
 
 After construction, the object can be used to send either single emails:


### PR DESCRIPTION
`log` is a required argument, and without `from` mailgun behaviour is unpredictable.

I would suggest a 1.0.1 where the hard dependency on log is removed (default to simply not logging) or replaced with something like [debug](https://www.npmjs.com/package/debug), as the current construction is kind of unintuitive (requiring a log object).