### PR TITLE
Other mailgun fields (v1.0.2)

### DIFF
--- a/lib/MailgunMustacheMailer.js
+++ b/lib/MailgunMustacheMailer.js
@@ -21,11 +21,16 @@ var MailgunMustacheMailer = module.exports = function(config, log) {
     this.sender = config.dryrun ? fileSender(config, log) : mailgunSender(config, log);
 };
 
-MailgunMustacheMailer.prototype.sendBatch = function(template, recipients, callback) {
+MailgunMustacheMailer.prototype.sendBatch = function(template, recipients, mailgunOptions, callback) {
+    if(!callback) {
+        callback = mailgunOptions;
+        mailgunOptions = {};
+    }
+
     if(!_.every(recipients, "email")) return setImmediate(callback, new Error("All recipients must have an email address"));
 
     async.mapLimit(recipients, this.config.sendingParallelism, (recipient, callback) => {
-        this.send(template, recipient, (error, mailId) => {
+        this.send(template, recipient, mailgunOptions, (error, mailId) => {
             if(error) return callback(null, { email: recipient.email, error });
 
             callback(null, { email: recipient.email, mailId: mailId });
@@ -33,12 +38,17 @@ MailgunMustacheMailer.prototype.sendBatch = function(template, recipients, callb
     }, callback);
 };
 
-MailgunMustacheMailer.prototype.send = function(template, recipient, callback) {
+MailgunMustacheMailer.prototype.send = function(template, recipient, mailgunOptions, callback) {
+    if(!callback) {
+        callback = mailgunOptions;
+        mailgunOptions = {};
+    }
+
     if(!recipient.email) return setImmediate(callback, new Error("Recipient must have an email address"));
 
     recipient.subject = mustache.render(template.subject, recipient);
     recipient.html = mustache.render(template.html, recipient);
     recipient.text = mustache.render(template.text, recipient);
 
-    this.sender(recipient, callback);
+    this.sender(recipient, mailgunOptions, callback);
 };

--- a/lib/senders/file.js
+++ b/lib/senders/file.js
@@ -2,11 +2,12 @@ const fs = require("fs");
 const uuid = require("uuid");
 
 module.exports = function(config, log) {
-    return (recipient, callback) => file(config, log, recipient, callback);
+    return (recipient, mailgunOptions, callback) => file(config, log, recipient, mailgunOptions, callback);
 };
 
-function file(config, log, recipient, callback) {
+function file(config, log, recipient, mailgunOptions, callback) {
     const mailId = uuid.v4();
+    fs.writeFileSync(`file-sender.${mailId}.${recipient.email}.${recipient.subject}.options`, JSON.stringify(mailgunOptions, null, 4));
     fs.writeFileSync(`file-sender.${mailId}.${recipient.email}.${recipient.subject}.html`, recipient.html);
     fs.writeFileSync(`file-sender.${mailId}.${recipient.email}.${recipient.subject}.text`, recipient.text);
 

--- a/lib/senders/mailgun.js
+++ b/lib/senders/mailgun.js
@@ -1,10 +1,10 @@
 const request = require("request");
 
 module.exports = function(config, log) {
-    return (recipient, callback) => mailgun(config, log, recipient, callback);
+    return (recipient, mailgunOptions, callback) => mailgun(config, log, recipient, mailgunOptions, callback);
 };
 
-function mailgun(config, log, recipient, callback) {
+function mailgun(config, log, recipient, mailgunOptions, callback) {
     var requestOptions = {
         url: "https://api.mailgun.net/v3/" + config.domain + "/messages",
         auth: {
@@ -16,13 +16,13 @@ function mailgun(config, log, recipient, callback) {
             to: recipient.name + " <" + recipient.email + ">",
             subject: recipient.subject,
             html: recipient.html,
-            text: recipient.text
+            text: recipient.text,
+            ...mailgunOptions
         }
     };
 
     request.post(requestOptions, (error, response, body) => {
         if(error) return callback(error);
-
 
         log.info(`Sent email to ${recipient.email}`);
         callback(null, body.id);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailgun-mustache-mailer",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "a library for sending mustache formatted mails via mailgun",
   "main": "index.js",
   "license": "MIT",

--- a/test/MailgunMustacheMailer.js
+++ b/test/MailgunMustacheMailer.js
@@ -66,6 +66,23 @@ describe("MailgunMustacheMailer", () => {
             });
         });
 
+        it("passes mailgun options through to the sender", (done) => {
+            mailgunMustacheMailer.send(template, recipient, {
+                someOption: true
+            }, (error) => {
+                c.expect(error).to.be.not.ok;
+                c.expect(senderFunction).to.have.been.calledWith({
+                    email: "asbjoern@deranged.dk",
+                    name: "Asbjørn Thegler",
+                    subject: "Hello Asbjørn Thegler!",
+                    text: "Hello Asbjørn Thegler!\n",
+                    html: "<p>Hello Asbjørn Thegler!</p>"
+                }, { someOption: true });
+
+                done();
+            });
+        });
+
         it("returns the id of the sent email", (done) => {
             mailgunMustacheMailer.send(template, recipient, (error, id) => {
                 c.expect(error).to.be.not.ok;
@@ -121,6 +138,38 @@ describe("MailgunMustacheMailer", () => {
                     text: "Hello Anders Enghøj!\n",
                     html: "<p>Hello Anders Enghøj!</p>"
                 });
+
+                done();
+            });
+        });
+
+        it("passes mailgun options through to the sender", (done) => {
+            mailgunMustacheMailer.sendBatch(template, recipients, {
+                someOption: true
+            }, (error) => {
+                c.expect(error).to.be.not.ok;
+
+                c.expect(senderFunction).to.have.been.calledWith({
+                    email: "asbjoern@deranged.dk",
+                    name: "Asbjørn Thegler",
+                    subject: "Hello Asbjørn Thegler!",
+                    text: "Hello Asbjørn Thegler!\n",
+                    html: "<p>Hello Asbjørn Thegler!</p>"
+                }, { someOption: true });
+                c.expect(senderFunction).to.have.been.calledWith({
+                    email: "niels@deranged.dk",
+                    name: "Niels Abildgaard",
+                    subject: "Hello Niels Abildgaard!",
+                    text: "Hello Niels Abildgaard!\n",
+                    html: "<p>Hello Niels Abildgaard!</p>"
+                }, { someOption: true });
+                c.expect(senderFunction).to.have.been.calledWith({
+                    email: "anders@deranged.dk",
+                    name: "Anders Enghøj",
+                    subject: "Hello Anders Enghøj!",
+                    text: "Hello Anders Enghøj!\n",
+                    html: "<p>Hello Anders Enghøj!</p>"
+                }, { someOption: true });
 
                 done();
             });

--- a/test/MailgunMustacheMailer.js
+++ b/test/MailgunMustacheMailer.js
@@ -9,7 +9,7 @@ describe("MailgunMustacheMailer", () => {
     beforeEach(() => {
         log = { info: s.stub() };
         config = { };
-        senderFunction = s.spy((recipient, callback) => setImmediate(callback, null, "some-sent-id"));
+        senderFunction = s.spy((recipient, mailgunOptions, callback) => setImmediate(callback, null, "some-sent-id"));
         sender = s.stub().returns(senderFunction);
 
         template = {
@@ -141,7 +141,7 @@ describe("MailgunMustacheMailer", () => {
         it("returns any errors during sending", (done) => {
             let count = 0;
             const mailError = new Error();
-            senderFunction.func = (recipient, callback) => {
+            senderFunction.func = (recipient, mailgunOptions, callback) => {
                 count++;
                 if(count === 1) return setImmediate(callback, mailError);
                 return setImmediate, callback(null, "some-sent-id");

--- a/test/senders/file.js
+++ b/test/senders/file.js
@@ -18,11 +18,11 @@ describe("file sender", () => {
         uuid = { v4: s.stub().returns("1234") };
         file = proxyquire(testSubject, { fs, uuid });
 
-        sender = file({ }, log);
+        sender = file({}, log);
     });
 
     it("writes two files to disk", (done) => {
-        sender(mail, (error) => {
+        sender(mail, {}, (error) => {
             c.expect(error).to.be.not.ok;
 
             c.expect(fs.writeFileSync).to.have.been.calledWith("file-sender.1234.asbjoern@deranged.dk.This email is important.text", "Read this!");

--- a/test/senders/file.js
+++ b/test/senders/file.js
@@ -21,10 +21,11 @@ describe("file sender", () => {
         sender = file({}, log);
     });
 
-    it("writes two files to disk", (done) => {
+    it("writes three files to disk", (done) => {
         sender(mail, {}, (error) => {
             c.expect(error).to.be.not.ok;
 
+            c.expect(fs.writeFileSync).to.have.been.calledWith("file-sender.1234.asbjoern@deranged.dk.This email is important.options", "{}");
             c.expect(fs.writeFileSync).to.have.been.calledWith("file-sender.1234.asbjoern@deranged.dk.This email is important.text", "Read this!");
             c.expect(fs.writeFileSync).to.have.been.calledWith("file-sender.1234.asbjoern@deranged.dk.This email is important.html", "<p>Read this!</p>");
 

--- a/test/senders/mailgun.js
+++ b/test/senders/mailgun.js
@@ -27,7 +27,7 @@ describe("file sender", () => {
     });
 
     it("succeeds posting to mailgun", (done) => {
-        sender(mail, (error) => {
+        sender(mail, {}, (error) => {
             c.expect(error).to.be.not.ok;
 
             c.expect(request.post).to.have.been.calledWith({
@@ -53,7 +53,7 @@ describe("file sender", () => {
         const mailgunError = new Error();
         request.post.func = (options, callback) => callback(mailgunError);
 
-        sender(mail, (error) => {
+        sender(mail, {}, (error) => {
             c.expect(error).to.equal(mailgunError);
 
             done();

--- a/test/senders/mailgun.js
+++ b/test/senders/mailgun.js
@@ -27,7 +27,7 @@ describe("file sender", () => {
     });
 
     it("succeeds posting to mailgun", (done) => {
-        sender(mail, {}, (error) => {
+        sender(mail, { someOption: true }, (error) => {
             c.expect(error).to.be.not.ok;
 
             c.expect(request.post).to.have.been.calledWith({
@@ -41,7 +41,8 @@ describe("file sender", () => {
                     to: "Asbjørn <asbjoern@deranged.dk>",
                     subject: "This email is important",
                     html: "<p>Read this!</p>",
-                    text: "Read this!"
+                    text: "Read this!",
+                    someOption: true
                 }
             });
 


### PR DESCRIPTION
Versioned as 1.0.2 under the assumption that #3 will be merged first.

This PR adds support for adding (optional) `mailgunOptions` to every request.

Concretely, this is useful if you want to set the Reply-To email of an email you send, which would need the API request to Mailgun to set `h:Reply-To` (see the `h:X-My_header` entry under parameters here: https://documentation.mailgun.com/en/latest/api-sending.html#sending).